### PR TITLE
Update to the DXC v1.7.2207, force windows-2019 with VS2019 in CI

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - name: Set git to use LF
       run: |

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ import os
 
 class DXCConan(ConanFile):
     name = "dxc"
-    version = "1.6.2112"
+    version = "1.6.2205"
     description = "DirectX Shader Compiler"
     license = "NCSA"
     topics = ("hlsl", "dxc", "compiler", "shader", "spirv")
@@ -17,7 +17,7 @@ class DXCConan(ConanFile):
 
     @property
     def _source_commit_or_tag(self):
-        return "v1.6.2112"
+        return "71fbb021fa0a8bb73d02fac0d3ddfade88974e20"
 
     @property
     def _source_subfolder(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ import os
 
 class DXCConan(ConanFile):
     name = "dxc"
-    version = "1.6.2205"
+    version = "1.7.2207"
     description = "DirectX Shader Compiler"
     license = "NCSA"
     topics = ("hlsl", "dxc", "compiler", "shader", "spirv")
@@ -17,7 +17,7 @@ class DXCConan(ConanFile):
 
     @property
     def _source_commit_or_tag(self):
-        return "71fbb021fa0a8bb73d02fac0d3ddfade88974e20"
+        return "v1.7.2207"
 
     @property
     def _source_subfolder(self):


### PR DESCRIPTION
DXC doesn't supports VS2022 yet