### PR TITLE
Update to the latest DXC with logical op intrinsics support

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
     - name: Set git to use LF
       run: |
@@ -65,7 +65,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: Install dependencies
-      run: pip3 install conan
+      run: brew install conan
     - name: Config
       env:
         CONAN_LOGIN_USERNAME: ${{ secrets.JFROG_USER }}

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ import os
 
 class DXCConan(ConanFile):
     name = "dxc"
-    version = "1.7.2207"
+    version = "1.7.2211"
     description = "DirectX Shader Compiler"
     license = "NCSA"
     topics = ("hlsl", "dxc", "compiler", "shader", "spirv")
@@ -17,7 +17,7 @@ class DXCConan(ConanFile):
 
     @property
     def _source_commit_or_tag(self):
-        return "v1.7.2207"
+        return "f9bc4f598b420ff211e82523580d8481caac8903"
 
     @property
     def _source_subfolder(self):


### PR DESCRIPTION
Fix macos Conan path issues in CI by installing via brew instead of pip
Switch to windows-2022 in CI as DXC already supports VS2022