### PR TITLE
Update to the DXC v1.8.2502, fix Linux and macos-x86_64 builds

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   windows:
+    if: false # disable
     runs-on: windows-2022
     steps:
     - name: Set git to use LF
@@ -71,7 +72,8 @@ jobs:
         conan upload "dxc" -r triada -c
 
   macos:
-    runs-on: macos-12
+    if: false # disable
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
       with:
@@ -99,6 +101,7 @@ jobs:
         conan upload "dxc" -r triada -c
 
   macos-armv8:
+    if: false # disable
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   windows:
-    if: false # disable
     runs-on: windows-2022
     steps:
     - name: Set git to use LF
@@ -44,7 +43,6 @@ jobs:
         conan upload "dxc" -r triada -c
 
   linux:
-    if: false # disable
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -101,7 +99,6 @@ jobs:
         conan upload "dxc" -r triada -c
 
   macos-armv8:
-    if: false # disable
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -101,6 +101,7 @@ jobs:
         conan upload "dxc" -r triada -c
 
   macos-armv8:
+    if: false # disable
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -44,6 +44,7 @@ jobs:
         conan upload "dxc" -r triada -c
 
   linux:
+    if: false # disable
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -72,7 +73,6 @@ jobs:
         conan upload "dxc" -r triada -c
 
   macos:
-    if: false # disable
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
@@ -101,7 +101,6 @@ jobs:
         conan upload "dxc" -r triada -c
 
   macos-armv8:
-    if: false # disable
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v4

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ import os
 
 class DXCConan(ConanFile):
     name = "dxc"
-    version = "1.8.2405"
+    version = "1.8.2502"
     description = "DirectX Shader Compiler"
     license = "NCSA"
     topics = ("hlsl", "dxc", "compiler", "shader", "spirv")
@@ -18,7 +18,7 @@ class DXCConan(ConanFile):
 
     @property
     def _source_commit_or_tag(self):
-        return "v1.8.2405"
+        return "v1.8.2502"
 
     @property
     def _source_subfolder(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -87,8 +87,8 @@ class DXCConan(ConanFile):
             self.package_copy("lib/libdxcompiler.so*", "lib")
             self.package_copy("bin/dxc*", "bin")
         elif self.settings.os == "Macos":
-            self.package_copy("lib/libdxcompiler.dylib", "lib")
-            self.package_copy("bin/dxc", "bin")
+            self.package_copy("lib/libdxcompiler.dylib*", "lib")
+            self.package_copy("bin/dxc*", "bin")
         else:
             raise ConanInvalidConfiguration("Unsupported OS: %s" % self.settings.os)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -53,12 +53,9 @@ class DXCConan(ConanFile):
         self.run("ninja -j 4")
 
     def build_macos(self):
-        if self.settings.arch == "x86_64":
-            self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_OSX_ARCHITECTURES=x86_64 -C %s" %
-                    (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
-        else:
-            self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -C %s" %
-                    (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
+        target_osx_arch = "x86_64" if self.settings.arch == "x86_64" else "arm64"
+        self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_OSX_ARCHITECTURES=%s -C %s" %
+                (self.build_folder, self._build_type, target_osx_arch, self._predefined_cmake_params_path), cwd=self._source_dir)
         self.run("ninja")
 
     def build(self):
@@ -90,8 +87,8 @@ class DXCConan(ConanFile):
             self.package_copy("lib/libdxcompiler.so*", "lib")
             self.package_copy("bin/dxc*", "bin")
         elif self.settings.os == "Macos":
-            self.package_copy("lib/libdxcompiler.dylib*", "lib")
-            self.package_copy("bin/dxc*", "bin")
+            self.package_copy("lib/libdxcompiler.dylib", "lib")
+            self.package_copy("bin/dxc", "bin")
         else:
             raise ConanInvalidConfiguration("Unsupported OS: %s" % self.settings.os)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,7 +48,7 @@ class DXCConan(ConanFile):
         self.run("cmake --build %s --target \"dxc\" --config Release" % self.build_folder )
 
     def build_linux(self):
-        self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-13 -DCMAKE_CXX_COMPILER=clang++-13 -C %s" %
+        self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16 -C %s" %
                  (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
         self.run("ninja -j 4")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -54,7 +54,7 @@ class DXCConan(ConanFile):
 
     def build_macos(self):
         if self.settings.arch == "x86_64":
-            self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_SYSTEM_PROCESSOR=x86_64 -C %s" %
+            self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_SYSTEM_PROCESSOR=x86_64 -DCMAKE_OSX_ARCHITECTURES=x86_64 -C %s" %
                     (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
         else:
             self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -C %s" %

--- a/conanfile.py
+++ b/conanfile.py
@@ -53,8 +53,12 @@ class DXCConan(ConanFile):
         self.run("ninja -j 4")
 
     def build_macos(self):
-        self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -C %s" %
-                 (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
+        if self.settings.arch == "x86_64":
+            self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_SYSTEM_PROCESSOR=x86_64 -C %s" %
+                    (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
+        else:
+            self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -C %s" %
+                    (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
         self.run("ninja")
 
     def build(self):

--- a/profiles/linux.profile
+++ b/profiles/linux.profile
@@ -2,9 +2,9 @@
 os=Linux
 arch=x86_64
 compiler=clang
-compiler.version=13
+compiler.version=16
 compiler.libcxx=libstdc++11
 
 [buildenv]
-CC=/usr/bin/clang-13
-CXX=/usr/bin/clang++-13
+CC=/usr/bin/clang-16
+CXX=/usr/bin/clang++-16


### PR DESCRIPTION
Use cross compiling on macos (arm64) nodes to build x86_64 binaries
Update no longer available macos-12 nodes and use macos-14 in GitHub CI workflow
Upgrade to Clang-16 on Linux