### PR TITLE
Update to the DXC v1.9.2602, use Clang for Windows build

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -34,6 +34,11 @@ jobs:
         ./.venv/Scripts/activate
         conan remote add triada ${{ secrets.ARTIFACTORY_URL }}
         conan remote login triada ${{ secrets.ARTIFACTORY_USER }}
+    - name: Add Windows SDK to PATH
+      shell: pwsh
+      run: |
+        $sdkBin = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\10.*\x64" | Sort-Object Name -Descending | Select-Object -First 1
+        echo "$($sdkBin.FullName)" >> $env:GITHUB_PATH
     - name: Build
       run: |
         ./.venv/Scripts/activate

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -34,11 +34,9 @@ jobs:
         ./.venv/Scripts/activate
         conan remote add triada ${{ secrets.ARTIFACTORY_URL }}
         conan remote login triada ${{ secrets.ARTIFACTORY_USER }}
-    - name: Add Windows SDK to PATH
-      shell: pwsh
-      run: |
-        $sdkBin = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin\10.*\x64" | Sort-Object Name -Descending | Select-Object -First 1
-        echo "$($sdkBin.FullName)" >> $env:GITHUB_PATH
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
     - name: Build
       run: |
         ./.venv/Scripts/activate

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -34,7 +34,7 @@ jobs:
         ./.venv/Scripts/activate
         conan remote add triada ${{ secrets.ARTIFACTORY_URL }}
         conan remote login triada ${{ secrets.ARTIFACTORY_USER }}
-    - uses: ilammy/msvc-dev-cmd@v1
+    - uses: ilammy/msvc-dev-cmd@v1 # Adds Windows SDK tools (mc.exe) to PATH, required by DXC build
       with:
         arch: x64
     - name: Build

--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -26,6 +26,7 @@ jobs:
         python3 -m venv .venv
         ./.venv/Scripts/activate
         python3 -m pip install conan
+        python3 -m pip install ninja
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ import os
 
 class DXCConan(ConanFile):
     name = "dxc"
-    version = "1.8.2502"
+    version = "1.9.2602"
     description = "DirectX Shader Compiler"
     license = "NCSA"
     topics = ("hlsl", "dxc", "compiler", "shader", "spirv")
@@ -18,7 +18,7 @@ class DXCConan(ConanFile):
 
     @property
     def _source_commit_or_tag(self):
-        return "v1.8.2502"
+        return "v1.9.2602"
 
     @property
     def _source_subfolder(self):
@@ -43,9 +43,9 @@ class DXCConan(ConanFile):
         return os.path.join(self._source_dir, "cmake/caches/PredefinedParams.cmake")
 
     def build_windows(self):
-        self.run("cmake . -B%s -A x64 -DCMAKE_BUILD_TYPE=%s -C %s" %
+        self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -C %s" %
                  (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
-        self.run("cmake --build %s --target \"dxc\" --config Release" % self.build_folder )
+        self.run("ninja -C %s dxc" % self.build_folder)
 
     def build_linux(self):
         self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16 -C %s" %
@@ -80,9 +80,9 @@ class DXCConan(ConanFile):
             self._source_dir, "include", "dxc"), keep_path=True)
 
         if self.settings.os == "Windows":
-            self.package_copy("Release/lib/dxcompiler.lib", "lib")
-            self.package_copy("Release/bin/dxcompiler.dll", "bin")
-            self.package_copy("Release/bin/dxc.exe", "bin")
+            self.package_copy("lib/dxcompiler.lib", "lib")
+            self.package_copy("bin/dxcompiler.dll", "bin")
+            self.package_copy("bin/dxc.exe", "bin")
         elif self.settings.os == "Linux":
             self.package_copy("lib/libdxcompiler.so*", "lib")
             self.package_copy("bin/dxc*", "bin")

--- a/conanfile.py
+++ b/conanfile.py
@@ -43,7 +43,7 @@ class DXCConan(ConanFile):
         return os.path.join(self._source_dir, "cmake/caches/PredefinedParams.cmake")
 
     def build_windows(self):
-        self.run("cmake . -B%s -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_FLAGS=-w -DCMAKE_CXX_FLAGS=-w -C %s" %
+        self.run('cmake . -B%s -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_FLAGS=-w -DCMAKE_CXX_FLAGS=-w -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -C %s' %
                  (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
         self.run("ninja -C %s dxc" % self.build_folder)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -43,7 +43,7 @@ class DXCConan(ConanFile):
         return os.path.join(self._source_dir, "cmake/caches/PredefinedParams.cmake")
 
     def build_windows(self):
-        self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -C %s" %
+        self.run("cmake . -B%s -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_FLAGS=-w -DCMAKE_CXX_FLAGS=-w -C %s" %
                  (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
         self.run("ninja -C %s dxc" % self.build_folder)
 

--- a/profiles/windows.profile
+++ b/profiles/windows.profile
@@ -1,6 +1,5 @@
 [settings]
 os=Windows
 arch=x86_64
-compiler=msvc
-compiler.version=193
-compiler.runtime=dynamic
+compiler=clang
+compiler.version=17


### PR DESCRIPTION
Enable LTO for Windows build
Suppress compile warnings because there are too many when using Clang for Windows