### PR TITLE
Modernize to Conan 2 style, update GitHub workflows and Conan profiles

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         git config --global core.autocrlf false
         git config --global core.eol lf
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
     - name: Revert to default CRLF
@@ -26,7 +26,6 @@ jobs:
         python3 -m venv .venv
         ./.venv/Scripts/activate
         python3 -m pip install conan
-        python3 -m pip install ninja
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
@@ -40,16 +39,16 @@ jobs:
     - name: Build
       run: |
         ./.venv/Scripts/activate
-        conan create . -pr:h profiles/windows.profile -pr:b profiles/windows.profile -b missing -s build_type=Release
+        conan create . -pr:h profiles/windows.profile -pr:b profiles/windows.profile -b missing
     - name: Upload
       run: |
         ./.venv/Scripts/activate
         conan upload "dxc" -r triada -c
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
     - name: Install dependencies
@@ -57,7 +56,6 @@ jobs:
         python3 -m venv .venv
         . .venv/bin/activate
         python3 -m pip install conan
-        python3 -m pip install ninja
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
@@ -68,16 +66,16 @@ jobs:
     - name: Build
       run: |
         . .venv/bin/activate
-        conan create . -pr:h profiles/linux.profile -pr:b profiles/linux.profile -b missing -s build_type=Release
+        conan create . -pr:h profiles/linux.profile -pr:b profiles/linux.profile -b missing
     - name: Upload
       run: |
         . .venv/bin/activate
         conan upload "dxc" -r triada -c
 
   macos:
-    runs-on: macos-14
+    runs-on: macos-15-intel
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
     - name: Install dependencies
@@ -85,7 +83,6 @@ jobs:
         python3 -m venv .venv
         . .venv/bin/activate
         python3 -m pip install conan
-        python3 -m pip install ninja
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
@@ -96,16 +93,16 @@ jobs:
     - name: Build
       run: |
         . .venv/bin/activate
-        conan create . -pr:h profiles/macos.profile -pr:b profiles/macos.profile -b missing -s build_type=Release
+        conan create . -pr:h profiles/macos.profile -pr:b profiles/macos.profile -b missing
     - name: Upload
       run: |
         . .venv/bin/activate
         conan upload "dxc" -r triada -c
 
   macos-armv8:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'recursive'
     - name: Install dependencies
@@ -113,7 +110,6 @@ jobs:
         python3 -m venv .venv
         . .venv/bin/activate
         python3 -m pip install conan
-        python3 -m pip install ninja
     - name: Config
       env:
         CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_APIKEY }}
@@ -124,7 +120,7 @@ jobs:
     - name: Build
       run: |
         . .venv/bin/activate
-        conan create . -pr:h profiles/macos-armv8.profile -pr:b profiles/macos-armv8.profile -b missing -s build_type=Release
+        conan create . -pr:h profiles/macos-armv8.profile -pr:b profiles/macos-armv8.profile -b missing
     - name: Upload
       run: |
         . .venv/bin/activate

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build
 build.*
+
+__pycache__
+test_package/CMakeUserPresets.json

--- a/conanfile.py
+++ b/conanfile.py
@@ -34,8 +34,9 @@ class DXCConan(ConanFile):
 
     def package_id(self):
         # dxcompiler exposes COM-style vtable interfaces with no std:: types crossing the ABI,
-        # so C++ standard doesn't matter to consumers
-        self.info.settings.rm_safe("compiler.cppstd")
+        # so the same Release binary serves any consumer compiler and build_type
+        del self.info.settings.compiler
+        del self.info.settings.build_type
 
     def source(self):
         git = Git(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,8 +1,12 @@
 from conan import ConanFile
-from conan.tools import files, scm
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy
+from conan.tools.scm import Git
 
 import os
+
+required_conan_version = ">=2.0.9"
 
 
 class DXCConan(ConanFile):
@@ -13,85 +17,68 @@ class DXCConan(ConanFile):
     topics = ("hlsl", "dxc", "compiler", "shader", "spirv")
     homepage = "https://github.com/microsoft/DirectXShaderCompiler"
     url = "https://github.com/triadastudio/conan-dxc"
+    package_type = "shared-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
 
-    @property
-    def _source_commit_or_tag(self):
-        return "v1.9.2602"
+    def layout(self):
+        cmake_layout(self, generator="Ninja", src_folder="src")
 
-    @property
-    def _source_subfolder(self):
-        return "source_subfolder"
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.27 <4]")
+        self.tool_requires("ninja/[>=1.11 <2]")
 
-    @property
-    def _build_type(self):
-        return "Release"
+    def validate(self):
+        if str(self.settings.os) not in ("Windows", "Linux", "Macos"):
+            raise ConanInvalidConfiguration(f"Unsupported OS: {self.settings.os}")
 
-    @property
-    def _source_dir(self):
-        return os.path.join(self.source_folder, self._source_subfolder)
+    def package_id(self):
+        # dxcompiler exposes COM-style vtable interfaces with no std:: types crossing the ABI,
+        # so C++ standard doesn't matter to consumers
+        self.info.settings.rm_safe("compiler.cppstd")
 
     def source(self):
-        self.run(f"git clone https://github.com/microsoft/DirectXShaderCompiler.git {self._source_subfolder}")
-        with files.chdir(self, self._source_subfolder):
-            self.run(f"git checkout {self._source_commit_or_tag}")
-            self.run("git submodule update --init --recursive")
+        git = Git(self)
+        git.clone(url="https://github.com/microsoft/DirectXShaderCompiler.git",
+                  target=".",
+                  args=["--depth", "1", "--branch", f"v{self.version}",
+                        "--recurse-submodules", "--shallow-submodules"])
 
-    @property
-    def _predefined_cmake_params_path(self):
-        return os.path.join(self._source_dir, "cmake/caches/PredefinedParams.cmake")
-
-    def build_windows(self):
-        self.run('cmake . -B%s -GNinja -Wno-dev -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_FLAGS=-w -DCMAKE_CXX_FLAGS=-w -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -C %s' %
-                 (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
-        self.run("ninja -C %s dxc" % self.build_folder)
-
-    def build_linux(self):
-        self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16 -C %s" %
-                 (self.build_folder, self._build_type, self._predefined_cmake_params_path), cwd=self._source_dir)
-        self.run("ninja -j 4")
-
-    def build_macos(self):
-        target_osx_arch = "x86_64" if self.settings.arch == "x86_64" else "arm64"
-        self.run("cmake . -B%s -GNinja -DCMAKE_BUILD_TYPE=%s -DCMAKE_OSX_ARCHITECTURES=%s -C %s" %
-                (self.build_folder, self._build_type, target_osx_arch, self._predefined_cmake_params_path), cwd=self._source_dir)
-        self.run("ninja")
+    def generate(self):
+        tc = CMakeToolchain(self, generator="Ninja")
+        if self.settings.os == "Windows":
+            # LLVM-3.7-era code is extremely warning-noisy under clang-cl
+            tc.extra_cflags.append("-w")
+            tc.extra_cxxflags.append("-w")
+            tc.cache_variables["CMAKE_INTERPROCEDURAL_OPTIMIZATION"] = True
+        tc.generate()
 
     def build(self):
-        if self.settings.os == "Windows":
-            self.build_windows()
-        elif self.settings.os == "Linux":
-            self.build_linux()
-        elif self.settings.os == "Macos":
-            self.build_macos()
-        else:
-            raise ConanInvalidConfiguration("Unsupported OS: %s" % self.settings.os)
-
-    def package_copy(self, pattern, dst_dir, keep_path=False, src_path = None):
-        if src_path is None:
-           src_path = self.build_folder
-
-        dst = os.path.join(self.package_folder, dst_dir)
-        files.copy(self, pattern, src=src_path, dst=dst, keep_path=keep_path)
+        cmake = CMake(self)
+        predefined_params = os.path.join(self.source_folder, "cmake", "caches", "PredefinedParams.cmake")
+        cmake.configure(cli_args=["-Wno-dev", f'-C "{predefined_params}"'])
+        # dxc depends on dxcompiler, so this single target builds everything package() needs
+        cmake.build(target="dxc")
 
     def package(self):
-        self.package_copy("*.h", "include", src_path=os.path.join(
-            self._source_dir, "include", "dxc"), keep_path=True)
+        copy(self, "LICENSE.TXT", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.h",
+             src=os.path.join(self.source_folder, "include", "dxc"),
+             dst=os.path.join(self.package_folder, "include"), keep_path=True)
 
+        lib_dst = os.path.join(self.package_folder, "lib")
+        bin_dst = os.path.join(self.package_folder, "bin")
         if self.settings.os == "Windows":
-            self.package_copy("lib/dxcompiler.lib", "lib")
-            self.package_copy("bin/dxcompiler.dll", "bin")
-            self.package_copy("bin/dxc.exe", "bin")
+            copy(self, "lib/dxcompiler.lib", src=self.build_folder, dst=lib_dst, keep_path=False)
+            copy(self, "bin/dxcompiler.dll", src=self.build_folder, dst=bin_dst, keep_path=False)
+            copy(self, "bin/dxc.exe", src=self.build_folder, dst=bin_dst, keep_path=False)
         elif self.settings.os == "Linux":
-            self.package_copy("lib/libdxcompiler.so*", "lib")
-            self.package_copy("bin/dxc*", "bin")
-        elif self.settings.os == "Macos":
-            self.package_copy("lib/libdxcompiler.dylib*", "lib")
-            self.package_copy("bin/dxc*", "bin")
-        else:
-            raise ConanInvalidConfiguration("Unsupported OS: %s" % self.settings.os)
+            copy(self, "lib/libdxcompiler.so*", src=self.build_folder, dst=lib_dst, keep_path=False)
+            copy(self, "bin/dxc*", src=self.build_folder, dst=bin_dst, keep_path=False)
+        else:  # Macos, guaranteed by validate()
+            copy(self, "lib/libdxcompiler.dylib*", src=self.build_folder, dst=lib_dst, keep_path=False)
+            copy(self, "bin/dxc*", src=self.build_folder, dst=bin_dst, keep_path=False)
 
     def package_info(self):
         self.cpp_info.libs = ["dxcompiler"]
-        self.cpp_info.includedirs = ["include"]

--- a/profiles/linux.profile
+++ b/profiles/linux.profile
@@ -1,10 +1,15 @@
 [settings]
 os=Linux
 arch=x86_64
+build_type=Release
 compiler=clang
 compiler.version=16
 compiler.libcxx=libstdc++11
+compiler.cppstd=17
 
 [buildenv]
 CC=/usr/bin/clang-16
 CXX=/usr/bin/clang++-16
+
+[conf]
+tools.build:jobs=4

--- a/profiles/macos-armv8.profile
+++ b/profiles/macos-armv8.profile
@@ -2,6 +2,11 @@
 os=Macos
 os.version=13.0
 arch=armv8
+build_type=Release
 compiler=apple-clang
 compiler.version=13
 compiler.libcxx=libc++
+compiler.cppstd=17
+
+[conf]
+tools.build:jobs=4

--- a/profiles/macos.profile
+++ b/profiles/macos.profile
@@ -1,7 +1,12 @@
 [settings]
 os=Macos
-os.version=10.15
+os.version=13.0
 arch=x86_64
+build_type=Release
 compiler=apple-clang
 compiler.version=13
 compiler.libcxx=libc++
+compiler.cppstd=17
+
+[conf]
+tools.build:jobs=4

--- a/profiles/windows.profile
+++ b/profiles/windows.profile
@@ -1,5 +1,12 @@
 [settings]
 os=Windows
 arch=x86_64
+build_type=Release
 compiler=clang
 compiler.version=17
+compiler.runtime=dynamic
+compiler.cppstd=17
+
+[conf]
+tools.build:compiler_executables={"c": "clang-cl", "cpp": "clang-cl"}
+tools.build:jobs=4

--- a/profiles/windows.profile
+++ b/profiles/windows.profile
@@ -5,6 +5,7 @@ build_type=Release
 compiler=clang
 compiler.version=17
 compiler.runtime=dynamic
+compiler.runtime_version=v144
 compiler.cppstd=17
 
 [conf]

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,15 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str, run=True)
+
+    def test(self):
+        if can_run(self):
+            self.run("dxc --version", env="conanrun")


### PR DESCRIPTION
Replace raw cmake/ninja calls with CMakeToolchain + CMake helper
Move compiler selection, build_type and worker count to profiles
Add run-only test_package, which calls dxc --version

Upgrade compiler and OS version required by Xcode 27 Beta
Update GitHub actions to use v5 runners
Use intel runner for macOS workflow

Update gitignore __pycache__ and CMakeUserPresets.json